### PR TITLE
fix rollupDB-levelDB chainID, remove exit-tree, add exitBalance & accumulatedHash

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,9 @@ module.exports = {
         "semi": [
             "error",
             "always"
+        ],
+        "space-infix-ops": [
+            "error"
         ]
     }
 };

--- a/src/batch-builder.js
+++ b/src/batch-builder.js
@@ -54,10 +54,10 @@ module.exports = class BatchBuilder {
         this.numBatchB = 32;
 
         this.L1TxFullB = this.fromEthAddrB + this.fromBjjCompressedB + 2 * this.maxIdxB + this.tokenIDB + 2 * this.f40B;
-        this.L1L2TxDataB = 2 * this.idxB + this.f40B + this.feeB;
+        this.L2TxDataB = 2 * this.idxB + this.f40B + this.feeB;
 
         const inputL1TxsFullB = this.maxL1Tx * this.L1TxFullB;
-        const inputTxsDataB = this.maxNTx * this.L1L2TxDataB;
+        const inputTxsDataB = this.maxNTx * this.L2TxDataB;
         const inputFeeTxsB = this.totalFeeTransactions * this.idxB;
 
         this.sha256InputsB = 2 * this.idxB + 2 * this.rootB + this.chainIDB + inputL1TxsFullB + inputTxsDataB + inputFeeTxsB;
@@ -1145,7 +1145,7 @@ module.exports = class BatchBuilder {
         let L1FullTxsData = this.getL1TxsFullData();
 
         // txsData
-        let txsData = this.getL1L2TxsData();
+        let txsData = this.getL2TxsData();
 
         // feeTxData
         const feeTxsData = this.getFeeTxsData();
@@ -1285,35 +1285,33 @@ module.exports = class BatchBuilder {
         if (!this.builded) throw new Error("Batch must first be builded");
 
         const dataNopTx = utils.padZeros("",
-            (this.maxNTx - this.offChainTxs.length - this.onChainTxs.length) * (this.L1L2TxDataB / 4));
+            (this.maxNTx - this.offChainTxs.length) * (this.L2TxDataB / 4));
         return  dataNopTx;
     }
 
     /**
-     * Return L1 & L2 data-availability padded with all unused L2 txs
-     * @return {String} L1 & L2 data-availability encoded as hexadecimal
+     * Return L2 data-availability padded with all unused L2 txs
+     * @return {String} L2 data-availability encoded as hexadecimal
      */
-    getL1L2TxsData() {
+    getL2TxsData() {
         if (!this.builded) throw new Error("Batch must first be builded");
 
-        const dataL1Tx = this._L1TxsData();
         const dataL2Tx = this._L2TxsData();
         const dataNopTx = this._nopTxsData();
 
-        return dataL1Tx.concat(dataL2Tx).concat(dataNopTx);
+        return dataL2Tx.concat(dataNopTx);
     }
 
     /**
-     * Return the L1 & L2 data-availability ready to send to the SC
-     * @return {String} L1 & L2 data encoded as hexadecimal
+     * Return the L2 data-availability ready to send to the SC
+     * @return {String} L2 data encoded as hexadecimal
      */
-    getL1L2TxsDataSM() {
+    getL2TxsDataSM() {
         if (!this.builded) throw new Error("Batch must first be builded");
 
-        const dataL1Tx = this._L1TxsData();
         const dataL2Tx = this._L2TxsData();
 
-        return `0x${dataL1Tx.concat(dataL2Tx)}`;
+        return `0x${dataL2Tx}`;
     }
 
     /**

--- a/src/float40.js
+++ b/src/float40.js
@@ -33,7 +33,7 @@ function fix2Float(_f) {
         e++;
     }
 
-    if (e>31) {
+    if (e > 31) {
         throw new Error("number too big");
     }
 
@@ -62,7 +62,7 @@ function floorFix2Float(_f){
         e++;
     }
 
-    if (e>31) {
+    if (e > 31) {
         throw new Error("number too big");
     }
 
@@ -89,7 +89,7 @@ function round(fix){
         e++;
     }
 
-    if (e>31) {
+    if (e > 31) {
         throw new Error("number too big");
     }
 

--- a/src/smt-leveldb.js
+++ b/src/smt-leveldb.js
@@ -13,8 +13,8 @@ const LevelDb = require("./level-db");
 class SMTLevelDb {
     /**
      * Initilize SMT levelDb class
-     * @param {String} pathDb - database path 
-     * @param {String} prefix - prefix to store [key - value] 
+     * @param {String} pathDb - database path
+     * @param {String} prefix - prefix to store [key - value]
      */
     constructor(pathDb, prefix) {
         this.db = new LevelDb(pathDb, prefix);
@@ -31,7 +31,7 @@ class SMTLevelDb {
 
     /**
      * Set new root
-     * @param {BigInt} rt - root to store 
+     * @param {BigInt} rt - root to store
      */
     async setRoot(rt) {
         await this.db.insert("smt-root", this._toString(rt));
@@ -51,7 +51,7 @@ class SMTLevelDb {
      * Get from string
      * normally used ti get from database
      * @param {String} - string to parse
-     * @returns {Any} 
+     * @returns {Any}
      */
     _fromString(val) {
         return unstringifyBigInts(JSON.parse(val));
@@ -69,7 +69,7 @@ class SMTLevelDb {
 
     /**
      * Normalize numbers to BigInts
-     * @param {Array} n 
+     * @param {Array} n
      */
     _normalize(n) {
         for (let i = 0; i < n.length; i++) {
@@ -79,7 +79,7 @@ class SMTLevelDb {
 
     /**
      * Get value given its key
-     * @param {BigInt} key 
+     * @param {BigInt} key
      * @returns {Any | undefined} - value, returns undefined if not found
      */
     async get(key) {
@@ -92,12 +92,12 @@ class SMTLevelDb {
 
     /**
      * Get multiples values
-     * @param {Array} keys 
+     * @param {Array} keys
      * @returns {Array} - values
      */
     async multiGet(keys) {
         const promises = [];
-        for (let i=0; i<keys.length; i++) {
+        for (let i = 0; i < keys.length; i++) {
             promises.push(this.get(keys[i]));
         }
         return await Promise.all(promises);
@@ -105,7 +105,7 @@ class SMTLevelDb {
 
     /**
      * Insert multiple [key - value] pairs
-     * @param {Array} inserts - array of [key - value]  
+     * @param {Array} inserts - array of [key - value]
      */
 
     async multiIns(inserts) {
@@ -119,7 +119,7 @@ class SMTLevelDb {
 
     /**
      * Deletes multiple key
-     * @param {Array} dels - keys to delete 
+     * @param {Array} dels - keys to delete
      */
     async multiDel(dels) {
         for (let i = 0; i < dels.length; i++) {

--- a/src/smt-tmp-db.js
+++ b/src/smt-tmp-db.js
@@ -1,7 +1,7 @@
 const Scalar = require("ffjavascript").Scalar;
 
 /**
- * Creates an in memory cached version of a tree 
+ * Creates an in memory cached version of a tree
  */
 class SMTTmpDb {
     constructor(srcDb) {
@@ -36,7 +36,7 @@ class SMTTmpDb {
      * @param {Array} n - Array of inserts
      */
     _normalize(n) {
-        for (let i=0; i<n.length; i++) {
+        for (let i = 0; i < n.length; i++) {
             n[i] = Scalar.e(n[i]);
         }
     }
@@ -64,7 +64,7 @@ class SMTTmpDb {
      */
     async multiGet(keys) {
         const promises = [];
-        for (let i=0; i<keys.length; i++) {
+        for (let i = 0; i < keys.length; i++) {
             promises.push(this.get(keys[i]));
         }
         return await Promise.all(promises);
@@ -83,7 +83,7 @@ class SMTTmpDb {
      * @param {Array} inserts - Array of keys
      */
     async multiIns(inserts) {
-        for (let i=0; i<inserts.length; i++) {
+        for (let i = 0; i < inserts.length; i++) {
             const keyS = this._key2str(inserts[i][0]);
             this._normalize(inserts[i][1]);
             if (this.deletes[keyS]) {
@@ -98,7 +98,7 @@ class SMTTmpDb {
      * @param {Array} dels - Array of keys
      */
     async multiDel(dels) {
-        for (let i=0; i<dels.length; i++) {
+        for (let i = 0; i < dels.length; i++) {
             const keyS = this._key2str(dels[i]);
             if (this.inserts[keyS]) {
                 delete this.inserts[keyS];

--- a/src/state-utils.js
+++ b/src/state-utils.js
@@ -4,6 +4,7 @@ const poseidonHash = require("circomlib").poseidon;
 const babyJub = require("circomlib").babyJub;
 
 const utils = require("./utils");
+const txUtils = require("./tx-utils");
 
 /**
  * Encode a state object into an array
@@ -12,21 +13,23 @@ const utils = require("./utils");
  */
 function state2Array(st) {
     let data = Scalar.e(0);
-    
-    data = Scalar.add(data, st.tokenID);
-    data = Scalar.add(data, Scalar.shl(st.nonce, 32));
-    data = Scalar.add(data, Scalar.shl(st.sign, 72));
+
+    data = Scalar.add(data, st.tokenID); // 32 bits
+    data = Scalar.add(data, Scalar.shl(st.nonce, 32)); // 40 bits
+    data = Scalar.add(data, Scalar.shl(st.sign, 72)); // 1 bit
 
     return [
         data,
         Scalar.e(st.balance),
         Scalar.fromString(st.ay, 16),
         Scalar.fromString(st.ethAddr, 16),
+        Scalar.e(st.exitBalance),
+        Scalar.e(st.accumulatedHash),
     ];
 }
 
 /**
- * Parse encoded array into a state object 
+ * Parse encoded array into a state object
  * @param {Array} a - Encoded array
  * @returns {Object} Merkle tree state object
  */
@@ -38,6 +41,8 @@ function array2State(a) {
         balance: Scalar.e(a[1]),
         ay: Scalar.e(a[2]).toString(16),
         ethAddr: "0x" + utils.padZeros(Scalar.e(a[3]).toString(16), 40),
+        exitBalance: Scalar.e(a[4]),
+        accumulatedHash: Scalar.e(a[5]),
     };
 }
 
@@ -65,9 +70,22 @@ function getAx(sign, ay){
     return point[0].toString(16);
 }
 
+/**
+ * compute accumulated hash given a tx
+ * @param {Scalar} previousHash - previous accumulated hash
+ * @param {Object} tx - transaction object
+ * @param {Number} nLevels - merkle tree depth
+ * @returns {Scalar} Next accumulated hash
+ */
+function computeAccumulatedHash(previousHash, tx, nLevels){
+    const dataAvailability = txUtils.encodeL2Tx(tx, nLevels);
+    return poseidonHash([previousHash, Scalar.fromString(dataAvailability, 16)]);
+}
+
 module.exports = {
     state2Array,
     array2State,
     hashState,
     getAx,
+    computeAccumulatedHash
 };

--- a/src/state-utils.js
+++ b/src/state-utils.js
@@ -78,7 +78,7 @@ function getAx(sign, ay){
  * @returns {Scalar} Next accumulated hash
  */
 function computeAccumulatedHash(previousHash, tx, nLevels){
-    const dataAvailability = txUtils.encodeL2Tx(tx, nLevels);
+    const dataAvailability = tx.onChain ? txUtils.encodeL1Tx(tx, nLevels) : txUtils.encodeL2Tx(tx, nLevels);
     return poseidonHash([previousHash, Scalar.fromString(dataAvailability, 16)]);
 }
 

--- a/src/tx-utils.js
+++ b/src/tx-utils.js
@@ -18,16 +18,16 @@ function encodeL1TxFull(tx) {
     const tokenIDB = 32;
     const idxB = 48; // MAX_NLEVELS
 
-    const L1TxFullB = fromEthAddrB + fromBjjCompressedB + 2*idxB + tokenIDB + 2*f40B;
+    const L1TxFullB = fromEthAddrB + fromBjjCompressedB + 2 * idxB + tokenIDB + 2 * f40B;
 
     let res = Scalar.e(0);
     res = Scalar.add(res, tx.toIdx || 0);
     res = Scalar.add(res, Scalar.shl(tx.tokenID || 0, idxB));
     res = Scalar.add(res, Scalar.shl(tx.amountF || 0, idxB + tokenIDB));
     res = Scalar.add(res, Scalar.shl(tx.loadAmountF || 0, idxB + tokenIDB + f40B));
-    res = Scalar.add(res, Scalar.shl(tx.fromIdx || 0, idxB + tokenIDB + 2*f40B));
-    res = Scalar.add(res, Scalar.shl(Scalar.fromString(tx.fromBjjCompressed || "0", 16), 2*idxB + tokenIDB + 2*f40B));
-    res = Scalar.add(res, Scalar.shl(Scalar.fromString(tx.fromEthAddr || "0", 16), fromBjjCompressedB + 2*idxB + tokenIDB + 2*f40B));
+    res = Scalar.add(res, Scalar.shl(tx.fromIdx || 0, idxB + tokenIDB + 2 * f40B));
+    res = Scalar.add(res, Scalar.shl(Scalar.fromString(tx.fromBjjCompressed || "0", 16), 2 * idxB + tokenIDB + 2 * f40B));
+    res = Scalar.add(res, Scalar.shl(Scalar.fromString(tx.fromEthAddr || "0", 16), fromBjjCompressedB + 2 * idxB + tokenIDB + 2 * f40B));
 
     return utils.padZeros(res.toString("16"), L1TxFullB / 4);
 }
@@ -50,10 +50,10 @@ function decodeL1TxFull(l1TxEncoded) {
     l1tx.tokenID = Scalar.toNumber(utils.extract(l1TxScalar, idxB, tokenIDB));
     l1tx.amountF = Scalar.toNumber(utils.extract(l1TxScalar, idxB + tokenIDB , f40B));
     l1tx.loadAmountF = Scalar.toNumber(utils.extract(l1TxScalar, idxB + tokenIDB + f40B, f40B));
-    l1tx.fromIdx = Scalar.toNumber(utils.extract(l1TxScalar, idxB + tokenIDB + 2*f40B, idxB));
-    const fromBjjCompressed =(utils.extract(l1TxScalar, 2*idxB + tokenIDB + 2*f40B, fromBjjCompressedB)).toString(16);
+    l1tx.fromIdx = Scalar.toNumber(utils.extract(l1TxScalar, idxB + tokenIDB + 2 * f40B, idxB));
+    const fromBjjCompressed = (utils.extract(l1TxScalar, 2 * idxB + tokenIDB + 2 * f40B, fromBjjCompressedB)).toString(16);
     l1tx.fromBjjCompressed = `0x${utils.padZeros(fromBjjCompressed.toString("16"), fromBjjCompressedB / 4)}`;
-    const fromEthAddr = (utils.extract(l1TxScalar, fromBjjCompressedB + 2*idxB + tokenIDB + 2*f40B, fromEthAddrB)).toString(16);
+    const fromEthAddr = (utils.extract(l1TxScalar, fromBjjCompressedB + 2 * idxB + tokenIDB + 2 * f40B, fromEthAddrB)).toString(16);
     l1tx.fromEthAddr = `0x${utils.padZeros(fromEthAddr.toString("16"), fromEthAddrB / 4)}`;
     l1tx.onChain = true;
 
@@ -263,7 +263,7 @@ function encodeL1Tx(tx, nLevels){
     const f40B = 40;
     const userFeeB = 8;
 
-    const L1TxB = 2*idxB + f40B + userFeeB;
+    const L1TxB = 2 * idxB + f40B + userFeeB;
 
     let res = Scalar.e(0);
     res = Scalar.add(res, Scalar.e(0)); // fee for L1 transaction is 0
@@ -308,7 +308,7 @@ function encodeL2Tx(tx, nLevels){
     const f40B = 40;
     const userFeeB = 8;
 
-    const L2TxB = 2*idxB + f40B + userFeeB;
+    const L2TxB = 2 * idxB + f40B + userFeeB;
 
     let finalToIdx = tx.toIdx;
     if (tx.toIdx == Constants.nullIdx){

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ const babyJub = require("circomlib").babyJub;
  */
 function padding256(n) {
     let nstr = Scalar.e(n).toString(16);
-    while (nstr.length < 64) nstr = "0"+nstr;
+    while (nstr.length < 64) nstr = "0" + nstr;
     nstr = `0x${nstr}`;
     return nstr;
 }

--- a/src/withdraw-utils.js
+++ b/src/withdraw-utils.js
@@ -2,8 +2,8 @@ const utils = require("./utils");
 const Constants = require("./constants");
 
 /**
- * @param {Object} inputs - Object containing all withdraw inputs 
- * @return {Scalar} hash global inputs with sha256 % rField 
+ * @param {Object} inputs - Object containing all withdraw inputs
+ * @return {Scalar} hash global inputs with sha256 % rField
  */
 function hashInputsWithdraw(inputs){
     const rootExitB = 256;
@@ -32,7 +32,7 @@ function hashInputsWithdraw(inputs){
     // build final inputs string
     const finalStr = strRootExit.concat(strEthAddr).concat(strTokenID).concat(strBalance)
         .concat(strIdx);
-    
+
     return utils.sha256Snark(finalStr);
 }
 

--- a/test/batch-builder.test.js
+++ b/test/batch-builder.test.js
@@ -875,20 +875,16 @@ describe("Rollup Db - batchbuilder", async function(){
         "000000000000";
 
         const resTxsData =
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000" +
-            "0000010000000101000000006400" +
             "000001000000010100000000327e" +
+            "0000000000000000000000000000" +
+            "0000000000000000000000000000" +
+            "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000";
 
-        const resTxsDataSM = "0x" +
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000" +
-            "0000010000000101000000006400" +
-            "000001000000010100000000327e";
+        const resTxsDataSM = "0x000001000000010100000000327e";
 
         const resFeeData = "00000104000001050000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -897,8 +893,8 @@ describe("Rollup Db - batchbuilder", async function(){
         + "000000000000000000000000000000000000000000000000000000000";
 
         const batchL1Data = await bb.getL1TxsFullData();
-        const batchTxsData = await bb.getL1L2TxsData();
-        const batchTxsDataSM = await bb.getL1L2TxsDataSM();
+        const batchTxsData = await bb.getL2TxsData();
+        const batchTxsDataSM = await bb.getL2TxsDataSM();
         const batchFeeData = await bb.getFeeTxsData();
 
         expect(resL1Data).to.be.equal(batchL1Data.toString());
@@ -907,7 +903,7 @@ describe("Rollup Db - batchbuilder", async function(){
         expect(resFeeData).to.be.equal(batchFeeData.toString());
 
         // input hash
-        const resInputHash = "19377456725856121152838237812130123789886310451262992986461154440516302272162";
+        const resInputHash = "6932249851646571237389724163539642577367515964488800375683596608337474035483";
 
         const batchInputHash = await bb.getHashInputs();
         expect(resInputHash).to.be.equal(batchInputHash.toString());
@@ -923,12 +919,12 @@ describe("Rollup Db - batchbuilder", async function(){
         await rollupDB.consolidate(bb);
 
         // Check L1, L2, Fee data
-        const resL1Data = "0".repeat(864+6*6*2);
-        const resL2Data = "0".repeat(176+8*3*2);
+        const resL1Data = "0".repeat(864 + 6 * 6 * 2);
+        const resL2Data = "0".repeat(176 + 8 * 3 * 2);
         const resFeeData = "0".repeat(512);
 
         const batchL1Data = await bb.getL1TxsFullData();
-        const batchL2Data = await bb.getL1L2TxsData();
+        const batchL2Data = await bb.getL2TxsData();
         const batchFeeData = await bb.getFeeTxsData();
 
         expect(batchL1Data.toString()).to.be.equal(resL1Data);

--- a/test/rollup-db.test.js
+++ b/test/rollup-db.test.js
@@ -132,7 +132,7 @@ async function assertDbs(memDb, toCheckDb){
     const memRoot = await memDb.db.getRoot();
     const checkRoot = await toCheckDb.db.getRoot();
     expect(memRoot.toString()).to.be.equal(checkRoot.toString());
-    
+
     // Check database
     const keys = Object.keys(memDb.db.nodes);
     for (const key of keys) {
@@ -143,7 +143,7 @@ async function assertDbs(memDb, toCheckDb){
 }
 
 describe("RollupDb: memDb - LevelDb", async function () {
-    
+
     let rollupMemDb;
     let rollupLevelDb;
 

--- a/test/state-utils.test.js
+++ b/test/state-utils.test.js
@@ -1,6 +1,7 @@
 const { expect } = require("chai");
 const Scalar = require("ffjavascript").Scalar;
 
+const Constants = require("../index").Constants;
 const stateUtils = require("../index").stateUtils;
 
 describe("Utils", function () {
@@ -13,6 +14,8 @@ describe("Utils", function () {
             sign: 1,
             ay: "144e7e10fd47e0c67a733643b760e80ed399f70e78ae97620dbb719579cd645d",
             ethAddr: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+            exitBalance: Scalar.e(78910),
+            accumulatedHash: Scalar.e(11121314)
         };
 
         const stateArray = stateUtils.state2Array(state);
@@ -24,11 +27,13 @@ describe("Utils", function () {
         expect(Scalar.eq(state.sign, stateDecoded.sign)).to.be.equal(true);
         expect(state.ay).to.be.equal(stateDecoded.ay);
         expect(state.ethAddr).to.be.equal(stateDecoded.ethAddr);
+        expect(Scalar.eq(state.exitBalance, stateDecoded.exitBalance)).to.be.equal(true);
+        expect(Scalar.eq(state.accumulatedHash, stateDecoded.accumulatedHash)).to.be.equal(true);
     });
 
     it("Hash state", async () => {
-        const hashState = "18540586105591347071343650193721839788171292271683733900727222337327741747399";
-        
+        const hashState = "21866955965937445343918870539532641557673308466220525821695163767541598385049";
+
         const state = {
             tokenID: 1,
             nonce: 49,
@@ -36,6 +41,8 @@ describe("Utils", function () {
             sign: "1",
             ay: "144e7e10fd47e0c67a733643b760e80ed399f70e78ae97620dbb719579cd645d",
             ethAddr: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf",
+            exitBalance: Scalar.e(78910),
+            accumulatedHash: Scalar.e(11121314)
         };
 
         const hash = stateUtils.hashState(state);
@@ -48,7 +55,80 @@ describe("Utils", function () {
         const sign = 1;
 
         const resAx = stateUtils.getAx(sign, ay);
-        
+
         expect(ax).to.be.equal(resAx);
+    });
+
+    it("Compute accumulatedHash", async () => {
+        const testVectors = [];
+
+        testVectors.push({
+            previousHash: Scalar.e(0),
+            nLevels: 16,
+            tx: {
+                toIdx: Scalar.sub(Scalar.shl(1, 16), 1),
+                fromIdx: Scalar.sub(Scalar.shl(1, 16), 1),
+                amount: Scalar.fromString("343597383670000000000000000000000000000000"), // 0xFFFFFFFFFF in float40
+                userFee: Scalar.sub(Scalar.shl(1, 8), 1),
+            },
+            nextAccmulatedHash: "2993961035884929808181072384169205205742051482970847885461362543783060445268",
+        });
+
+        testVectors.push({
+            previousHash: Scalar.e(0),
+            nLevels: 32,
+            tx: {
+                toIdx: Scalar.sub(Scalar.shl(1, 32), 1),
+                fromIdx: Scalar.sub(Scalar.shl(1, 32), 1),
+                amount: Scalar.fromString("343597383670000000000000000000000000000000"), // 0xFFFFFFFFFF in float40
+                userFee: Scalar.sub(Scalar.shl(1, 8), 1),
+            },
+            nextAccmulatedHash: "20362841926573862215069519214140397310944218102006969434206408997767832213658",
+        });
+
+        testVectors.push({
+            previousHash: Scalar.e(0),
+            nLevels: 32,
+            tx: {
+                toIdx: 0,
+                fromIdx: 0,
+                amount: 0,
+                userFee: 0,
+                auxToIdx: 0,
+            },
+            nextAccmulatedHash: "14744269619966411208579211824598458697587494354926760081771325075741142829156",
+        });
+
+        testVectors.push({
+            previousHash: Scalar.e(0),
+            nLevels: 32,
+            tx: {
+                toIdx: Constants.nullIdx,
+                fromIdx: 1061,
+                amount: Scalar.fromString("420000000000"),
+                userFee: 127,
+                auxToIdx: 333,
+            },
+            nextAccmulatedHash: "16554556163037278008794315740010979134677207255019241373008007370078365251659",
+        });
+
+        testVectors.push({
+            previousHash: Scalar.e(0),
+            nLevels: 32,
+            tx: {
+                toIdx: 256,
+                fromIdx: 257,
+                amount: Scalar.fromString("79000000"),
+                userFee: 201,
+            },
+            nextAccmulatedHash: "12811856022258017950349510240770625834102074605559167883649872075697698792430",
+        });
+
+        for(let i = 0; i < testVectors.length; i++){
+            const { previousHash, tx, nLevels, nextAccmulatedHash } = testVectors[i];
+
+            const computeHash = stateUtils.computeAccumulatedHash(previousHash, tx, nLevels);
+            expect(computeHash.toString()).to.be.equal(nextAccmulatedHash);
+        }
     });
 });

--- a/test/tx-utils.test.js
+++ b/test/tx-utils.test.js
@@ -7,7 +7,6 @@ const float40 = require("../index").float40;
 const Constants = require("../index").Constants;
 
 describe("Tx-utils", function () {
-
     it("tx compressed data", async () => {
         const tx = {
             chainID: 1,


### PR DESCRIPTION
This PR does the following:
- fix loading rollupDB from LevelDB
- removes exit-tree
- adds `exitBalance` & `accumulatedHash` in state-tree leafs
- updates `zkInputs` to match new protocol

Please, refer to the follwoing specification for more details: https://github.com/hermeznetwork/docs/blob/feature/update-v1/docs/developers/protocol/hermez-protocol/protocol.md

close #26 