### PR TITLE
unchanged accHash if amountNullified & change tx order: L1, Nop, L2

### DIFF
--- a/test/batch-builder.test.js
+++ b/test/batch-builder.test.js
@@ -875,14 +875,14 @@ describe("Rollup Db - batchbuilder", async function(){
         "000000000000";
 
         const resTxsData =
-            "000001000000010100000000327e" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
             "0000000000000000000000000000" +
-            "0000000000000000000000000000";
+            "0000000000000000000000000000" +
+            "000001000000010100000000327e";
 
         const resTxsDataSM = "0x000001000000010100000000327e";
 
@@ -903,7 +903,7 @@ describe("Rollup Db - batchbuilder", async function(){
         expect(resFeeData).to.be.equal(batchFeeData.toString());
 
         // input hash
-        const resInputHash = "6932249851646571237389724163539642577367515964488800375683596608337474035483";
+        const resInputHash = "18489165602096978856602580072378708182780688698641839456008570926730041949263";
 
         const batchInputHash = await bb.getHashInputs();
         expect(resInputHash).to.be.equal(batchInputHash.toString());


### PR DESCRIPTION
This PR adds the following:
- if amount has been nullified, `accumulatedHash` is not computed
- switch transaction order to [L1Txs, NopTxs, L2Txs] instead of [L1Txs, L2Txs, NopTxs] to join empty data-availability

## Explanation

### nullified amount
If an amount is nulllified means that the L1 transaction has not been valid. Therefore, accumulated hash will not take into account that transaction.

### Tx order
Empty data-availability is together which make easy for circuits and contracts to pad `nopTx` and `L1Tx` just in one side of the data-availability bytes array

closes #31 