### PR TITLE
implement massive-migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "setup": "npm i",
-    "eslint": "npx eslint src/**",
+    "eslint": "npx eslint src/** test/*.js test/**/*.js ",
     "test": "npx mocha ./test/*.test.js"
   },
   "author": "HermezDAO",

--- a/src/batch-builder.js
+++ b/src/batch-builder.js
@@ -58,7 +58,7 @@ module.exports = class BatchBuilder {
         const inputTxsDataB = this.maxNTx * this.L2TxDataB;
         const inputFeeTxsB = this.totalFeeTransactions * this.idxB;
 
-        this.sha256InputsB = 2 * this.idxB + 2 * this.rootB + this.chainIDB + inputL1TxsFullB + inputTxsDataB + inputFeeTxsB;
+        this.sha256InputsB = 2 * this.maxIdxB + 2 * this.rootB + this.chainIDB + inputL1TxsFullB + inputTxsDataB + inputFeeTxsB;
     }
 
     /**
@@ -1144,6 +1144,7 @@ module.exports = class BatchBuilder {
 
         return utils.sha256Snark(finalStr);
     }
+
     /**
      * Computes string in hexadecimal of all pretended public inputs
      * @return {String} Public input string encoded as hexadecimal
@@ -1303,6 +1304,28 @@ module.exports = class BatchBuilder {
         const dataNopTx = utils.padZeros("",
             (this.maxNTx - this.offChainTxs.length) * (this.L2TxDataB / 4));
         return dataNopTx;
+    }
+
+    /**
+     * Return L1 & L2 data-availability
+     * @return {Array} L1 & L2 data-availability in an array
+     */
+    getL1L2TxsData() {
+        if (!this.builded) throw new Error("Batch must first be builded");
+
+        const arrayL1L2Data = [];
+        
+        for (let i = 0; i < this.onChainTxs.length; i++){
+            const tx = this.onChainTxs[i];
+            arrayL1L2Data.push(Scalar.fromString(txUtils.encodeL1Tx(tx, this.nLevels), 16));
+        }
+
+        for (let i = 0; i < this.offChainTxs.length; i++){
+            const tx = this.offChainTxs[i];
+            arrayL1L2Data.push(Scalar.fromString(txUtils.encodeL2Tx(tx, this.nLevels), 16));
+        }
+
+        return arrayL1L2Data;
     }
 
     /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,6 +23,9 @@ module.exports.DB_NumBatch_AxAy = poseidonHash([string2Int("Rollup_DB_NumBatch_A
 module.exports.DB_NumBatch_EthAddr = poseidonHash([string2Int("Rollup_DB_NumBatch_EthAddr")]);
 module.exports.DB_InitialIdx = poseidonHash([string2Int("Rollup_DB_Initial_Idx")]);
 module.exports.DB_ChainID = poseidonHash([string2Int("Rollup_DB_ChainID")]);
+module.exports.DB_L1L2Data = poseidonHash([string2Int("Rollup_DB_L1L2Data")]);
+module.exports.DB_nLevels = poseidonHash([string2Int("Rollup_DB_nLevels")]);
+module.exports.DB_Migration_idx = poseidonHash([string2Int("Rollup_DB_Migration_idx")]);
 
 module.exports.defaultChainID = 0;
 module.exports.firstIdx = 255;
@@ -38,3 +41,5 @@ module.exports.onlyExitBjjAy = "0x1fffffffffffffffffffffffffffffffffffffffffffff
 module.exports.createAccountMsg = "Account creation";
 module.exports.EIP712Version = "1";
 module.exports.EIP712Provider = "Hermez Network";
+module.exports.minBatchesToMigrate = 10;
+module.exports.minTxToMigrate = 100;

--- a/src/migration-builder.js
+++ b/src/migration-builder.js
@@ -1,0 +1,841 @@
+const assert = require("assert");
+const Scalar = require("ffjavascript").Scalar;
+const poseidonHash = require("circomlib").poseidon;
+const SMT = require("circomlib").SMT;
+
+const SMTTmpDb = require("./smt-tmp-db");
+const feeUtils = require("./fee-table");
+const utils = require("./utils");
+const stateUtils = require("./state-utils");
+const txUtils = require("./tx-utils");
+const Constants = require("./constants");
+
+/**
+ * Builds and process migration transactions
+ */
+class MigrationBuilder {
+    constructor(
+        rollupDB,
+        batchNumber,
+        root,
+        initialIdx,
+        maxMigrationTx,
+        nLevels,
+        sourceRollupDB,
+        initBatchToMigrate,
+        finalBatchToMigrate,
+        migrationIdx
+    ) {
+        assert((nLevels % 8) == 0);
+        this.rollupDB = rollupDB;
+        this.batchNumber = batchNumber;
+        this.currentNumBatch = Scalar.e(batchNumber);
+        this.initialIdx = initialIdx;
+        this.finalIdx = initialIdx;
+        this.maxMigrationTx = maxMigrationTx;
+        this.nLevels = nLevels;
+        this.dbState = new SMTTmpDb(rollupDB.db);
+        this.stateTree = new SMT(this.dbState, root);
+
+        this.sourceRollupDB = sourceRollupDB;
+        this.initBatchToMigrate = initBatchToMigrate;
+        this.finalBatchToMigrate = finalBatchToMigrate;
+        this.totalBatches = this.finalBatchToMigrate - this.initBatchToMigrate + 1;
+        this.migrationIdx = migrationIdx;
+
+        this.accumulatedFee = Scalar.e(0);
+
+        this._initBits();
+    }
+
+    /**
+     * Initialize parameters
+     */
+    _initBits(){
+        this.maxIdxB = Constants.maxNlevels;
+        this.idxB = this.nLevels;
+        this.rootB = 256;
+        this.chainIDB = 16;
+        this.fromEthAddrB = 160;
+        this.fromBjjCompressedB = 256;
+        this.f40B = 40;
+        this.tokenIDB = 32;
+        this.feeB = 8;
+        this.numBatchB = 32;
+    }
+
+    /**
+     * Build the migration batch
+     * Adds all the transactions and calculate the inputs for the circuit
+     */
+    async build(){
+        await this._sanityChecks();
+
+        this.input = {
+            // Intermediary States to parallelize witness computation
+            // decode-compute-acc-hash
+            imOutAccHash: [],
+            imOutCounter: [],
+            // rollup-tx
+            imStateRoot: [],
+            imAccFeeOut: [],
+            imOutIdx: [],
+            // hash global inputs
+            imFinalOutIdx: this.finalIdx,
+            // fee-tx
+            imInitStateRootFeeTx: 0,
+            imFinalAccFee: 0,
+
+            // inputs to compute hash global inputs
+            initSourceStateRoot: await this.sourceRollupDB.getStateRoot(this.initBatchToMigrate),
+            finalSourceStateRoot: await this.sourceRollupDB.getStateRoot(this.finalBatchToMigrate),
+            oldStateRoot: this.stateTree.root,
+            oldLastIdx: this.finalIdx,
+            migrationIdx: this.migrationIdx,
+            feeIdx: this.feeIdx || 0, // 0 means no fee is collected
+            totalBatchesToMigrate: this.totalBatches,
+
+            // signals needed to proof accumulatedHash in initSourceStateRoot & finalSourceStateRoot
+            tokenID: 0,
+            initBalance: 0,
+            finalBalance: 0,
+            ethAddr: 0,
+            initExitBalance: 0,
+            finalExitBalance: 0,
+            initAccHash: 0,
+            finalAccHash: 0,
+            initSiblings: [],
+            finalSiblings: [],
+
+            // data availability for each transaction to process
+            L1L2TxsData: [],
+
+            // signals to proof fromIdx[nTx] data correctness
+            tokenID1: [],
+            nonce1: [],
+            sign1: [],
+            balance1: [],
+            ay1: [],
+            ethAddr1: [],
+            exitBalance1: [],
+            accumulatedHash1: [],
+            siblings1: [],
+
+            // signals needed to process migration transactions
+            // signaling add balance to the same leaf or create new one
+            idxDestiny: [],
+            // receiver state
+            nonce2: [],
+            balance2: [],
+            exitBalance2: [],
+            accumulatedHash2: [],
+            siblings2: [],
+            // Required for inserts and deletes
+            isOld0_2: [],
+            oldKey2: [],
+            oldValue2: [],
+
+            tokenID3: 0,
+            nonce3: 0,
+            sign3: 0,
+            balance3: 0,
+            ay3: 0,
+            ethAddr3: 0,
+            exitBalance3: 0,
+            accumulatedHash3: 0,
+            siblings3: []
+        };
+
+        await this._proofAccHashInitAndFinal();
+        await this._proofCorrectnessDataAvailability();
+        await this._minBatchMinTxCheck();
+        await this._processMigrateTxs();
+
+        for (let i = this.totalMigrationTx; i < this.maxMigrationTx; i++){
+            await this._addNopTx(i);
+        }
+
+        await this._processFeeTxs();
+
+        this.builded = true;
+    }
+
+    /**
+     * Verify accumulated hash for init and final batch
+     */
+    async _proofAccHashInitAndFinal(){
+        const initState = await this.sourceRollupDB.getStateTreeInfo(this.migrationIdx, this.initBatchToMigrate);
+        const finalState = await this.sourceRollupDB.getStateTreeInfo(this.migrationIdx, this.finalBatchToMigrate);
+
+        this.input.tokenID = Scalar.e(initState.state.tokenID);
+        this.input.initBalance = Scalar.e(initState.state.balance);
+        this.input.finalBalance = Scalar.e(finalState.state.balance);
+        this.input.ethAddr = Scalar.fromString(finalState.state.ethAddr, 16);
+        this.input.initExitBalance = Scalar.e(initState.state.exitBalance);
+        this.input.finalExitBalance = Scalar.e(finalState.state.exitBalance);
+        this.input.initAccHash = Scalar.e(initState.state.accumulatedHash);
+        this.input.finalAccHash = Scalar.e(finalState.state.accumulatedHash);
+
+        let initSiblings = initState.siblings;
+        while (initSiblings.length < this.nLevels + 1) initSiblings.push(Scalar.e(0));
+        let finalSiblings = finalState.siblings;
+        while (finalSiblings.length < this.nLevels + 1) finalSiblings.push(Scalar.e(0));
+
+        this.input.initSiblings = initSiblings;
+        this.input.finalSiblings = finalSiblings;
+    }
+
+    /**
+     * Verify data availability data
+     */
+    async _proofCorrectnessDataAvailability(){
+        // get data-availability for all batches processed
+        let allL1L2Data = [];
+
+        for (let i = 0; i < this.totalBatches; i++){
+            const numBatch = this.initBatchToMigrate + i;
+            const l1L2Data = await this.sourceRollupDB.getL1L2Data(numBatch);
+            allL1L2Data = [...allL1L2Data, ...l1L2Data];
+        }
+
+        // filter by toIdx
+        const finalL1L2Data = allL1L2Data.filter(data => (txUtils.decodeL2Tx(data, this.nLevels)).toIdx === Scalar.toNumber(this.migrationIdx));
+        this.totalMigrationTx = finalL1L2Data.length;
+
+        let tmpAccHash = this.input.initAccHash;
+
+        for (let i = 0; i < this.totalMigrationTx; i++){
+            const fromIdx = (txUtils.decodeL2Tx(finalL1L2Data[i], this.nLevels)).fromIdx;
+            const state = await this.sourceRollupDB.getStateTreeInfo(fromIdx, this.finalBatchToMigrate);
+
+            this.input.L1L2TxsData[i] = Scalar.fromString(finalL1L2Data[i], 16);
+            this.input.tokenID1[i] = Scalar.e(state.state.tokenID);
+            this.input.nonce1[i] = Scalar.e(state.state.nonce);
+            this.input.sign1[i] = Scalar.e(state.state.sign);
+            this.input.balance1[i] = Scalar.e(state.state.balance);
+            this.input.ay1[i] = Scalar.fromString(state.state.ay, 16);
+            this.input.ethAddr1[i] = Scalar.fromString(state.state.ethAddr, 16);
+            this.input.exitBalance1[i] = Scalar.e(state.state.exitBalance);
+            this.input.accumulatedHash1[i] = Scalar.e(state.state.accumulatedHash);
+
+            let siblings = state.siblings;
+            while (siblings.length < this.nLevels + 1) siblings.push(Scalar.e(0));
+
+            this.input.siblings1[i] = siblings;
+
+            tmpAccHash = stateUtils.computeAccumulatedHash(tmpAccHash, txUtils.decodeL2Tx(finalL1L2Data[i], this.nLevels), this.nLevels);
+
+            // intermediary signals
+            if (i < this.maxMigrationTx - 1) {
+                this.input.imOutAccHash[i] = tmpAccHash;
+                this.input.imOutCounter[i] = i + 1;
+            }
+        }
+    }
+
+    /**
+     * Process all migration transactions
+     */
+    async _processMigrateTxs(){
+        for (let i = 0; i < this.totalMigrationTx; i++){
+            // check if a leaf could be updated: must match tokenID, sign, ay & ethAddr
+            // get states by ethAddr
+            const idxDestiny = await this._findIdx(i);
+            const op = (idxDestiny === 0) ? "INSERT" : "UPDATE";
+
+            let oldState;
+            let newState;
+            let fee2Charge;
+            let depositAmount;
+            const L1L2Hex = txUtils.scalarToHexL2Data(this.input.L1L2TxsData[i]);
+            const dataTx = txUtils.decodeL2Tx(L1L2Hex, this.nLevels);
+
+            fee2Charge = feeUtils.computeFee(dataTx.amount, dataTx.userFee);
+
+            const underFlowOk = Scalar.geq(Scalar.sub(dataTx.amount, fee2Charge), 0);
+            if (underFlowOk){
+                depositAmount = Scalar.sub(dataTx.amount, fee2Charge);
+            } else {
+                depositAmount = 0;
+                fee2Charge = dataTx.amount;
+            }
+
+            this.accumulatedFee = Scalar.add(this.accumulatedFee, fee2Charge);
+
+            if (op === "INSERT"){
+                this.finalIdx += 1;
+                this.input.idxDestiny[i] = Scalar.e(0);
+
+                // build new state
+                oldState = {
+                    balance: Scalar.e(0),
+                    tokenID: this.input.tokenID1[i],
+                    nonce: 0,
+                    sign: this.input.sign1[i],
+                    ay: this.input.ay1[i].toString(16),
+                    ethAddr: this.input.ethAddr1[i].toString(16),
+                    exitBalance: Scalar.e(0),
+                    accumulatedHash: Scalar.e(0)
+                };
+
+                newState = Object.assign({}, oldState);
+                newState.balance = depositAmount;
+
+                const newValue = stateUtils.hashState(newState);
+                const res = await this.stateTree.insert(this.finalIdx, newValue);
+                let siblings = res.siblings;
+                while (siblings.length < this.nLevels + 1) siblings.push(Scalar.e(0));
+
+                // State 2
+                this.input.nonce2[i] = Scalar.e(0x1234); // should not matter
+                this.input.balance2[i] = Scalar.e(0x1234); // should not matter
+                this.input.exitBalance2[i] = Scalar.e(0x1234); // should not matter
+                this.input.accumulatedHash2[i] = Scalar.e(0x1234); // should not matter
+                this.input.siblings2[i] = siblings;
+                this.input.isOld0_2[i] = Scalar.e(res.isOld0 ? 1 : 0);
+                this.input.oldKey2[i] = Scalar.e(res.isOld0 ? 0 : res.oldKey);
+                this.input.oldValue2[i] = Scalar.e(res.isOld0 ? 0 : res.oldValue);
+
+                // Database AxAy
+                const keyAxAy = Scalar.add( Scalar.add(Constants.DB_AxAy, newState.sign), Scalar.fromString(newState.ay, 16));
+                const lastAxAyStates = await this.dbState.get(keyAxAy);
+
+                // get last state and add last batch number
+                let valStatesAxAy;
+                let lastAxAyState;
+                if (!lastAxAyStates) {
+                    lastAxAyState = null;
+                    valStatesAxAy = [];
+                }
+                else {
+                    valStatesAxAy = [...lastAxAyStates];
+                    lastAxAyState = valStatesAxAy.slice(-1)[0];
+                }
+                if (!valStatesAxAy.includes(this.currentNumBatch)){
+                    valStatesAxAy.push(this.currentNumBatch);
+                    await this.dbState.multiIns([
+                        [keyAxAy, valStatesAxAy],
+                    ]);
+                }
+
+                // get last state
+                let valOldAxAy = null;
+                if (lastAxAyState){
+                    const keyOldAxAyBatch = poseidonHash([keyAxAy, lastAxAyState]);
+                    valOldAxAy = await this.dbState.get(keyOldAxAyBatch);
+                }
+
+                let newValAxAy;
+                if (!valOldAxAy) newValAxAy = [];
+                else newValAxAy = [...valOldAxAy];
+                newValAxAy.push(Scalar.e(this.finalIdx));
+                // new key newValAxAy
+                const newKeyAxAyBatch = poseidonHash([keyAxAy, this.currentNumBatch]);
+                await this.dbState.multiIns([
+                    [newKeyAxAyBatch, newValAxAy],
+                ]);
+
+                // Database Ether address
+                const keyEth = Scalar.add(Constants.DB_EthAddr, Scalar.fromString(newState.ethAddr, 16));
+                const lastEthStates = await this.dbState.get(keyEth);
+
+                // get last state and add last batch number
+                let valStatesEth;
+                let lastEthState;
+                if (!lastEthStates) {
+                    lastEthState = null;
+                    valStatesEth = [];
+                } else {
+                    valStatesEth = [...lastEthStates];
+                    lastEthState = valStatesEth.slice(-1)[0];
+                }
+                if (!valStatesEth.includes(this.currentNumBatch)){
+                    valStatesEth.push(this.currentNumBatch);
+                    await this.dbState.multiIns([
+                        [keyEth, valStatesEth],
+                    ]);
+                }
+
+                // get last state
+                let valOldEth = null;
+                if (lastEthState){
+                    const keyOldEthBatch = poseidonHash([keyEth, lastEthState]);
+                    valOldEth = await this.dbState.get(keyOldEthBatch);
+                }
+
+                let newValEth;
+                if (!valOldEth) newValEth = [];
+                else newValEth = [...valOldEth];
+                newValEth.push(Scalar.e(this.finalIdx));
+
+                // new key newValEth
+                const newKeyEthBatch = poseidonHash([keyEth, this.currentNumBatch]);
+
+                await this.dbState.multiIns([
+                    [newKeyEthBatch, newValEth],
+                ]);
+
+                // Database Idx
+                // get array of states saved by batch
+                const lastIdStates = await this.dbState.get(Scalar.add(Constants.DB_Idx, this.finalIdx));
+                // add last batch number
+                let valStatesId;
+                if (!lastIdStates) valStatesId = [];
+                else valStatesId = [...lastIdStates];
+                if (!valStatesId.includes(this.currentNumBatch)) valStatesId.push(this.currentNumBatch);
+
+                // new state for idx
+                const newValueId = poseidonHash([newValue, this.finalIdx]);
+
+                // new entry according idx and batchNumber
+                const keyIdBatch = poseidonHash([this.finalIdx, this.currentNumBatch]);
+
+                await this.dbState.multiIns([
+                    [newValueId, stateUtils.state2Array(newState)],
+                    [keyIdBatch, newValueId],
+                    [Scalar.add(Constants.DB_Idx, this.finalIdx), valStatesId],
+                ]);
+
+            } else if (op === "UPDATE"){
+                this.input.idxDestiny[i] = Scalar.e(idxDestiny);
+
+                const resFind = await this.stateTree.find(idxDestiny);
+                if (!resFind.found) {
+                    throw new Error(`ERROR: Idx ${idxDestiny} not found`);
+                }
+
+                const foundValueId = poseidonHash([resFind.foundValue, idxDestiny]);
+                oldState = stateUtils.array2State(await this.dbState.get(foundValueId));
+
+                newState = Object.assign({}, oldState);
+                newState.balance = Scalar.add(oldState.balance, depositAmount);
+
+                const newValue = stateUtils.hashState(newState);
+                const res = await this.stateTree.update(idxDestiny, newValue);
+                let siblings = res.siblings;
+                while (siblings.length < this.nLevels + 1) siblings.push(Scalar.e(0));
+
+                // State 2
+                this.input.nonce2[i] = Scalar.e(oldState.nonce);
+                this.input.balance2[i] = Scalar.e(oldState.balance);
+                this.input.exitBalance2[i] = Scalar.e(oldState.exitBalance);
+                this.input.accumulatedHash2[i] = Scalar.e(oldState.accumulatedHash);
+                this.input.siblings2[i] = siblings;
+                this.input.isOld0_2[i] = Scalar.e(0);
+                this.input.oldKey2[i] = Scalar.e(0x1234); // should not matter
+                this.input.oldValue2[i] = Scalar.e(0x1234); // should not matter
+
+                // get array of states saved by batch
+                const lastIdStates = await this.dbState.get(Scalar.add(Constants.DB_Idx, idxDestiny));
+                // add last batch number
+                let valStatesId;
+                if (!lastIdStates) valStatesId = [];
+                else valStatesId = [...lastIdStates];
+                if (!valStatesId.includes(this.currentNumBatch)) valStatesId.push(this.currentNumBatch);
+
+                // new state for idx
+                const newValueId = poseidonHash([newValue, idxDestiny]);
+
+                // new entry according idx and batchNumber
+                const keyIdBatch = poseidonHash([idxDestiny, this.currentNumBatch]);
+
+                await this.dbState.multiIns([
+                    [newValueId, stateUtils.state2Array(newState)],
+                    [keyIdBatch, newValueId],
+                    [Scalar.add(Constants.DB_Idx, idxDestiny), valStatesId]
+                ]);
+            }
+
+            // Database numBatch - Idx
+            const keyNumBatchIdx = Scalar.add(Constants.DB_NumBatch_Idx, this.currentNumBatch);
+            let lastBatchIdx = await this.dbState.get(keyNumBatchIdx);
+
+            // get last state and add last batch number
+            let newBatchIdx;
+            if (!lastBatchIdx) lastBatchIdx = [];
+            newBatchIdx = [...lastBatchIdx];
+
+            if (op == "INSERT") {
+                if (!newBatchIdx.includes(this.finalIdx)) newBatchIdx.push(this.finalIdx);
+            }
+
+            if (op == "UPDATE") {
+                if (!newBatchIdx.includes(idxDestiny)) newBatchIdx.push(idxDestiny);
+            }
+
+            await this.dbState.multiIns([
+                [keyNumBatchIdx, newBatchIdx],
+            ]);
+
+            // Database NumBatch
+            if (op == "INSERT") {
+            // AxAy
+                const hashAxAy = poseidonHash([newState.sign, Scalar.fromString(newState.ay, 16)]);
+                const keyNumBatchAxAy = Scalar.add(Constants.DB_NumBatch_AxAy, this.currentNumBatch);
+                let oldStatesAxAy = await this.dbState.get(keyNumBatchAxAy);
+                let newStatesAxAy;
+                if (!oldStatesAxAy) oldStatesAxAy = [];
+                newStatesAxAy = [...oldStatesAxAy];
+                if (!newStatesAxAy.includes(hashAxAy)) {
+                    newStatesAxAy.push(hashAxAy);
+                    await this.dbState.multiIns([
+                        [hashAxAy, [newState.sign, Scalar.fromString(newState.ay, 16)]],
+                        [keyNumBatchAxAy, newStatesAxAy],
+                    ]);
+                }
+                // EthAddress
+                const ethAddr =  Scalar.fromString(newState.ethAddr, 16);
+                const keyNumBatchEthAddr = Scalar.add(Constants.DB_NumBatch_EthAddr, this.currentNumBatch);
+                let oldStatesEthAddr = await this.dbState.get(keyNumBatchEthAddr);
+                let newStatesEthAddr;
+                if (!oldStatesEthAddr) oldStatesEthAddr = [];
+                newStatesEthAddr = [...oldStatesEthAddr];
+                if (!newStatesEthAddr.includes(ethAddr)) {
+                    newStatesEthAddr.push(ethAddr);
+                    await this.dbState.multiIns([
+                        [keyNumBatchEthAddr, newStatesEthAddr],
+                    ]);
+                }
+            }
+
+            // intermediary signals
+            if (i < this.maxMigrationTx - 1) {
+                this.input.imOutIdx[i] = this.finalIdx;
+                this.input.imStateRoot[i] = this.stateTree.root;
+                this.input.imAccFeeOut[i] = this.accumulatedFee;
+            }
+        }
+        this.input.imFinalOutIdx = this.finalIdx;
+    }
+
+    /**
+     * find idx with similar state fields to update
+     * @param {Number} txPos -  migration transaction position
+     * @returns idxDestiny (0 means INSERT)
+     */
+    async _findIdx(txPos){
+        // check first temporary states
+        const keyEth = Scalar.add(Constants.DB_EthAddr, Scalar.fromString(this.input.ethAddr1[txPos].toString(16), 16));
+        const newKeyEthBatch = poseidonHash([keyEth, this.currentNumBatch]);
+        const newIdxs = await this.dbState.get(newKeyEthBatch);
+
+        if (newIdxs){
+            // return the first match
+            for (let i = 0; i < newIdxs.length ; i++){
+                const resFind = await this.stateTree.find(newIdxs[i]);
+                const foundValueId = poseidonHash([resFind.foundValue, newIdxs[i]]);
+                const state = stateUtils.array2State(await this.dbState.get(foundValueId));
+
+                if (
+                    Scalar.eq(state.tokenID, this.input.tokenID1[txPos]) &&
+                    Scalar.eq(state.sign, this.input.sign1[txPos]) &&
+                    Scalar.eq(Scalar.fromString(state.ay, 16), this.input.ay1[txPos]) &&
+                    Scalar.eq(Scalar.fromString(state.ethAddr, 16), this.input.ethAddr1[txPos])
+                ){
+                    return newIdxs[i];
+                }
+            }
+        }
+
+        // check saved accounts
+        const idxsCandidates = await this.rollupDB.getIdxsByEthAddr(this.input.ethAddr1[txPos].toString(16));
+        if (idxsCandidates !== null){
+            // return the first match
+            for (let i = 0; i < idxsCandidates.length; i++){
+                const state = await this.rollupDB.getStateByIdx(idxsCandidates[i]);
+
+                if (
+                    Scalar.eq(state.tokenID, this.input.tokenID1[txPos]) &&
+                    Scalar.eq(state.sign, this.input.sign1[txPos]) &&
+                    Scalar.eq(Scalar.fromString(state.ay, 16), this.input.ay1[txPos]) &&
+                    Scalar.eq(Scalar.fromString(state.ethAddr, 16), this.input.ethAddr1[txPos])
+                ){
+                    return idxsCandidates[i];
+                }
+            }
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Process fee tx
+     */
+    async _processFeeTxs(){
+        const op = (typeof this.feeIdx === "undefined") ? "NOP" : "UPDATE";
+
+        const feeIdx = this.feeIdx;
+        let oldState;
+
+        this.input.imInitStateRootFeeTx = this.stateTree.root;
+        this.input.imFinalAccFee = this.accumulatedFee;
+
+        if (op === "UPDATE"){
+            const resFind = await this.stateTree.find(feeIdx);
+            if (resFind.found){
+                const foundValueId = poseidonHash([resFind.foundValue, feeIdx]);
+                oldState = stateUtils.array2State(await this.dbState.get(foundValueId));
+                // check tokenID matches feeIdx with tokenID transactions
+                if (!Scalar.eq(oldState.tokenID, this.input.tokenID)){
+                    throw new Error("ERROR: feeIdx tokenID does not match with tokenID of migrationIdx");
+                }
+            } else {
+                throw new Error("ERROR: feeIdx does not exist");
+            }
+
+            const newState = Object.assign({}, oldState);
+            newState.balance = Scalar.add(newState.balance, this.accumulatedFee);
+
+            const newValue = stateUtils.hashState(newState);
+
+            const res = await this.stateTree.update(feeIdx, newValue);
+            let siblings = res.siblings;
+            while (siblings.length < this.nLevels + 1) siblings.push(Scalar.e(0));
+
+            // StateFee i
+            // get the input from the oldState
+            this.input.tokenID3 = oldState.tokenID;
+            this.input.nonce3 = oldState.nonce;
+            this.input.sign3 = Scalar.e(oldState.sign);
+            this.input.balance3 = oldState.balance;
+            this.input.ay3 = Scalar.fromString(oldState.ay, 16);
+            this.input.ethAddr3 = Scalar.fromString(oldState.ethAddr, 16);
+            this.input.exitBalance3 = Scalar.e(oldState.exitBalance);
+            this.input.accumulatedHash3 = Scalar.e(oldState.accumulatedHash);
+            this.input.siblings3 = siblings;
+
+            // Update DB
+            // get array of states saved by batch
+            const lastIdStates = await this.dbState.get(Scalar.add(Constants.DB_Idx, feeIdx));
+            // add last batch number
+            let valStatesId;
+            if (!lastIdStates) valStatesId = [];
+            else valStatesId = [...lastIdStates];
+            if (!valStatesId.includes(this.currentNumBatch)) valStatesId.push(this.currentNumBatch);
+
+            // new state for idx
+            const newValueId = poseidonHash([newValue, feeIdx]);
+
+            // new entry according idx and batchNumber
+            const keyIdBatch = poseidonHash([feeIdx, this.currentNumBatch]);
+
+            await this.dbState.multiIns([
+                [newValueId, stateUtils.state2Array(newState)],
+                [keyIdBatch, newValueId],
+                [Scalar.add(Constants.DB_Idx, feeIdx), valStatesId]
+            ]);
+
+            // Database numBatch - Idx
+            const keyNumBatchIdx = Scalar.add(Constants.DB_NumBatch_Idx, this.currentNumBatch);
+            let lastBatchIdx = await this.dbState.get(keyNumBatchIdx);
+
+            // get last state and add last batch number
+            let newBatchIdx;
+            if (!lastBatchIdx) lastBatchIdx = [];
+            newBatchIdx = [...lastBatchIdx];
+
+            if (!newBatchIdx.includes(feeIdx)) newBatchIdx.push(feeIdx);
+
+            await this.dbState.multiIns([
+                [keyNumBatchIdx, newBatchIdx],
+            ]);
+        } else if (op === "NOP"){
+            this._addNopTxFee();
+        }
+    }
+
+    /**
+     * Add nop transaction to collect fees
+     */
+    async _addNopTxFee(){
+        this.input.tokenID3 = Scalar.e(0);
+        this.input.nonce3 = Scalar.e(0);
+        this.input.sign3 = Scalar.e(0);
+        this.input.balance3 = Scalar.e(0);
+        this.input.ay3 = Scalar.e(0);
+        this.input.ethAddr3 = Scalar.e(0);
+        this.input.exitBalance3 = Scalar.e(0);
+        this.input.accumulatedHash3 = Scalar.e(0);
+
+        this.input.siblings3 = [];
+        for (let i = 0; i < this.nLevels + 1; i++) {
+            this.input.siblings3[i] = Scalar.e(0);
+        }
+    }
+
+    /**
+     * Add an empty transaction
+     * @param {Number} i transaction index
+     */
+    async _addNopTx(i) {
+        this.input.L1L2TxsData[i] = Scalar.e(0);
+        this.input.tokenID1[i] = Scalar.e(0);
+        this.input.nonce1[i] = Scalar.e(0);
+        this.input.sign1[i] = Scalar.e(0);
+        this.input.balance1[i] = Scalar.e(0);
+        this.input.ay1[i] = Scalar.e(0);
+        this.input.ethAddr1[i] = Scalar.e(0);
+        this.input.exitBalance1[i] = Scalar.e(0);
+        this.input.accumulatedHash1[i] = Scalar.e(0);
+
+        this.input.siblings1[i] = [];
+        for (let j = 0; j < this.nLevels + 1; j++) {
+            this.input.siblings1[i][j] = Scalar.e(0);
+        }
+
+        this.input.idxDestiny[i] = Scalar.e(0);
+        this.input.nonce2[i] = Scalar.e(0);
+        this.input.balance2[i] = Scalar.e(0);
+        this.input.exitBalance2[i] = Scalar.e(0);
+        this.input.accumulatedHash2[i] = Scalar.e(0);
+
+        this.input.siblings2[i] = [];
+        for (let j = 0; j < this.nLevels + 1; j++) {
+            this.input.siblings2[i][j] = Scalar.e(0);
+        }
+
+        this.input.isOld0_2[i] = Scalar.e(0);
+        this.input.oldKey2[i] = Scalar.e(0);
+        this.input.oldValue2[i] = Scalar.e(0);
+
+        // intermediary signals
+        if (i < this.maxMigrationTx - 1) {
+            this.input.imOutIdx[i] = this.finalIdx;
+            this.input.imStateRoot[i] = this.stateTree.root;
+            this.input.imAccFeeOut[i] = this.accumulatedFee;
+            this.input.imOutAccHash[i] = (i == 0) ? this.input.initAccHash : this.input.imOutAccHash[i - 1];
+            this.input.imOutCounter[i] = (i == 0) ? Scalar.e(0) : this.input.imOutCounter[i - 1];
+        }
+    }
+
+    /**
+     * Return the circuit input
+     * @return {Object} Circuit input
+     */
+    getInput() {
+        if (!this.builded) throw new Error("ERROR: Batch must first be builded");
+        return this.input;
+    }
+
+    /**
+     * Return the pretended public inputs
+     * @return {Object} Circuit pretended public inputs
+     */
+    getPretendedPublicInputs(){
+        if (!this.builded) throw new Error("ERROR: Batch must first be builded");
+
+        return {
+            initSourceStateRoot: this.input.initSourceStateRoot,
+            finalSourceStateRoot: this.input.finalSourceStateRoot,
+            oldStateRoot: this.input.oldStateRoot,
+            newStateRoot: this.stateTree.root,
+            oldLastIdx: this.input.oldLastIdx,
+            newLastIdx: this.finalIdx,
+            migrationIdx: this.migrationIdx,
+            feeIdx: this.feeIdx || 0,
+            batchesToMigrate: this.totalBatches
+        };
+    }
+
+    /**
+     * Computes hash of all pretended public inputs
+     * @return {Scalar} hash global input
+     */
+    getHashInputs(){
+        if (!this.builded) throw new Error("ERROR: Batch must first be builded");
+        const finalStr = this.getInputsStr();
+
+        return utils.sha256Snark(finalStr);
+    }
+
+    /**
+     * Computes string in hexadecimal of all pretended public inputs
+     * @return {String} Public input string encoded as hexadecimal
+     */
+    getInputsStr(){
+        if (!this.builded) throw new Error("ERROR: Batch must first be builded");
+
+        const inputs = this.getPretendedPublicInputs();
+
+        // string hexacecimal initSourceStateRoot
+        let strInitSourceStateRoot = utils.padZeros(inputs.initSourceStateRoot.toString("16"), this.rootB / 4);
+
+        // string hexacecimal finalSourceStateRoot
+        let strFinalSourceStateRoot = utils.padZeros(inputs.finalSourceStateRoot.toString("16"), this.rootB / 4);
+
+        // string hexacecimal oldStateRoot
+        let strOldStateRoot = utils.padZeros(inputs.oldStateRoot.toString("16"), this.rootB / 4);
+
+        // string hexacecimal newStateRoot
+        let strNewStateRoot = utils.padZeros(inputs.newStateRoot.toString("16"), this.rootB / 4);
+
+        // string oldLastIdx, newLastIdx, migrateIdx and feeIdx
+        let res = Scalar.e(0);
+        res = Scalar.add(res, inputs.feeIdx);
+        res = Scalar.add(res, Scalar.shl(inputs.migrationIdx, this.maxIdxB));
+        res = Scalar.add(res, Scalar.shl(inputs.newLastIdx, 2 * this.maxIdxB));
+        res = Scalar.add(res, Scalar.shl(inputs.oldLastIdx, 3 * this.maxIdxB));
+        const finalIdxStr = utils.padZeros(res.toString("16"), (4 * this.maxIdxB) / 4);
+
+        // string hexacecimal totalBatches
+        let strCurrentNumBatch = utils.padZeros(inputs.batchesToMigrate.toString("16"), this.numBatchB / 4);
+
+        // build input string
+        const finalStr = strInitSourceStateRoot
+            .concat(strFinalSourceStateRoot)
+            .concat(strOldStateRoot)
+            .concat(strNewStateRoot)
+            .concat(finalIdxStr)
+            .concat(strCurrentNumBatch);
+
+        return finalStr;
+    }
+
+    /**
+     * Return data related to migration build related with the Rollup SC
+     * @return {Object} Contains all SC related data
+     */
+    async getDataSC(){
+        if (!this.builded) throw new Error("ERROR: Batch must first be builded");
+
+        return {
+            newStateRootMigrations: this.stateTree.root,
+            feeIdxCoordinator: this.feeIdx || 0,
+            accountsToMigrate: this.accountToMigrate,
+            batchToMigrate: this.finalBatchToMigrate,
+            newLastIdx: this.finalIdx
+        };
+    }
+
+    /**
+     * Check exiting batches to migrate
+     */
+    async _sanityChecks(){
+        const sourceCurrentBlock = this.sourceRollupDB.lastBatch;
+
+        if (this.initBatchToMigrate > sourceCurrentBlock){
+            throw new Error("ERROR: Initial batch to migrate does not exist");
+        }
+
+        if (this.finalBatchToMigrate > sourceCurrentBlock){
+            throw new Error("ERROR: Final batch to migrate does not exist");
+        }
+    }
+
+    /**
+     * Check minimum bacthes to process or minim transactions to process
+     */
+    async _minBatchMinTxCheck(){
+        if (Constants.minBatchesToMigrate > this.totalBatches){
+            if (this.totalMigrationTx < Constants.minTxToMigrate){
+                throw new Error("ERROR: Not enough batches to migrate neither enough transactions");
+            }
+        }
+    }
+
+    async setFeeIdx(idx){
+        this.feeIdx = idx;
+    }
+}
+
+module.exports = MigrationBuilder;

--- a/src/tx-utils.js
+++ b/src/tx-utils.js
@@ -350,6 +350,24 @@ function decodeL2Tx(l2TxEncoded, nLevels){
 }
 
 /**
+ * Converts L2Data from its bigint encoding to its hexadecimal representation
+ * @param {Scalar} - L2 Data in its Scalar representation
+ * @param {Number} nLevels - merkle tree depth
+ * @param {String} - L2 Data in its hexadecimal string representation
+ */
+function scalarToHexL2Data(scalarL2Data, nLevels){
+    const idxB = nLevels;
+    const f40B = 40;
+    const userFeeB = 8;
+    const L2TxB = 2 * idxB + f40B + userFeeB;
+
+    const hexL2Data = scalarL2Data.toString(16);
+
+    return utils.padZeros(hexL2Data, L2TxB / 4);
+}
+
+
+/**
  * Build and sign message to be sent to the coordinator
  * This message will be used by the coordinator to create accounts
  * @param {Object} wallet - Signer ethers
@@ -422,5 +440,6 @@ module.exports = {
     decodeL2Tx,
     encodeL1Tx,
     decodeL1Tx,
+    scalarToHexL2Data,
     signBjjAuth
 };

--- a/test/fee-table.test.js
+++ b/test/fee-table.test.js
@@ -267,7 +267,7 @@ describe("Fee table", function () {
             ["255", "9223372036854775808000000000000000000"],
         ];
 
-        const amount = Scalar.e(10**18);
+        const amount = Scalar.e(10 ** 18);
 
         for (let i = 0; i < testVector.length; i++){
             const feeSelector = testVector[i][0];
@@ -279,7 +279,7 @@ describe("Fee table", function () {
     });
 
     it("Compute fee error fee selected", () =>{
-        const amount = Scalar.e(10**18);
+        const amount = Scalar.e(10 ** 18);
         const nonExistingFeeSelected = 257;
         try {
             computeFee(amount, nonExistingFeeSelected);

--- a/test/float40.test.js
+++ b/test/float40.test.js
@@ -17,7 +17,7 @@ describe("Float40", function () {
             [0xFFFFFFFFFF, "343597383670000000000000000000000000000000"],
         ];
 
-        for (let i=0; i<testVector.length; i++) {
+        for (let i = 0; i < testVector.length; i++) {
             const fx = float40.float2Fix(testVector[i][0]);
             expect(fx.toString()).to.be.equal(testVector[i][1]);
 

--- a/test/migration-builder.test.js
+++ b/test/migration-builder.test.js
@@ -1,0 +1,354 @@
+const { expect } = require("chai");
+const Scalar = require("ffjavascript").Scalar;
+const SMTMemDB = require("circomlib").SMTMemDB;
+
+const Account = require("../index").HermezAccount;
+const RollupDB = require("../index").RollupDB;
+const Constants = require("../index").Constants;
+const feeUtils = require("../index").feeTable;
+const { depositTx, depositOnlyExitTx } = require("./helpers/test-utils");
+
+describe("RollupDb - migrationBuilder", async function(){
+    this.timeout(60000);
+
+    const nLevels = 32;
+    const maxTx = 8;
+    const maxL1Tx = 6;
+
+    const maxMigrationTx = 200;
+
+    it("Should process two migration transactions with fees", async () => {
+        // RollupSourceDB
+        const db = new SMTMemDB();
+        const rollupSourceDB = await RollupDB(db);
+        const bb = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        const account1 = new Account(1);
+        const account2 = new Account(2);
+        const account3 = new Account(3);
+        const accountDestRollup = new Account(4);
+
+        depositTx(bb, account1, 1, 1000);
+        depositTx(bb, account2, 1, 2000);
+        depositOnlyExitTx(bb, accountDestRollup, 1, 0);
+
+        const migrationIdx = 258;
+
+        await bb.build();
+        await rollupSourceDB.consolidate(bb);
+
+        const bb2 = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+        // two sends to exit-only account
+        const tx = {
+            fromIdx: 256,
+            toIdx: 258,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 0,
+            userFee: 125,
+        };
+
+        const tx2 = {
+            fromIdx: 257,
+            toIdx: 258,
+            tokenID: 1,
+            amount: Scalar.e(100),
+            nonce: 0,
+            userFee: 127,
+        };
+
+        account1.signTx(tx);
+        account2.signTx(tx2);
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+
+        await bb2.build();
+        await rollupSourceDB.consolidate(bb2);
+
+        // add empty batches to migrate minBatches
+        const bbToBuild = 10;
+
+        while (rollupSourceDB.lastBatch < bbToBuild){
+            const bb = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await rollupSourceDB.consolidate(bb);
+        }
+
+        // RollupDestinyDB
+        const destDb = new SMTMemDB();
+        const rollupDestDB = await RollupDB(destDb);
+        const destBb = await rollupDestDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        depositTx(destBb, account2, 1, 2000);
+        depositTx(destBb, account3, 1, 0);
+        await rollupDestDB.setMigrationIdx(migrationIdx);
+
+        await destBb.build();
+        await rollupDestDB.consolidate(destBb);
+        const oldStateRoot = rollupDestDB.stateRoot;
+        const oldLastBatch = rollupDestDB.lastBatch;
+        const oldInitialIdx = rollupDestDB.initialIdx;
+
+        // migration-builder
+        const initBatch = 1;
+        const finalBatch = 10;
+
+        const mb = await rollupDestDB.buildMigration(maxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+        mb.setFeeIdx(257);
+
+        await mb.build();
+        await rollupDestDB.consolidateMigrate(mb);
+
+        // check accounts has been migrated correctly
+        const feeTx1 = feeUtils.computeFee(tx.amount, tx.userFee);
+        const feeTx2 = feeUtils.computeFee(tx2.amount, tx2.userFee);
+
+        const source1 = await rollupSourceDB.getStateByIdx(256);
+        const source2 = await rollupSourceDB.getStateByIdx(257);
+        const source3 = await rollupSourceDB.getStateByIdx(258);
+
+        const dest1 = await rollupDestDB.getStateByIdx(256);
+        const dest2 = await rollupDestDB.getStateByIdx(257);
+        const dest3 = await rollupDestDB.getStateByIdx(258);
+
+        // account2 to be updated in dest1 leaf
+        expect(dest1.sign).to.be.equal(source2.sign);
+        expect(dest1.ay).to.be.equal(source2.ay);
+        expect(dest1.ethAddr).to.be.equal(source2.ethAddr);
+        expect(dest1.balance.toString()).to.be.equal(Scalar.add(2000, Scalar.sub(tx2.amount, feeTx2)).toString());
+        expect(dest1.tokenID).to.be.equal(source2.tokenID);
+        expect(dest1.nonce).to.be.equal(0);
+        expect(dest1.exitBalance.toString()).to.be.equal(Scalar.e(0).toString());
+        expect(dest1.accumulatedHash.toString()).to.be.equal(Scalar.e(0).toString());
+
+        // account1 to insert a new leaf in dest3
+        expect(dest3.sign).to.be.equal(source1.sign);
+        expect(dest3.ay).to.be.equal(source1.ay);
+        expect(dest3.ethAddr).to.be.equal(source1.ethAddr);
+        expect(dest3.balance.toString()).to.be.equal(Scalar.sub(tx.amount, feeTx1).toString());
+        expect(dest3.tokenID).to.be.equal(source1.tokenID);
+        expect(dest3.nonce).to.be.equal(0);
+        expect(dest3.exitBalance.toString()).to.be.equal(Scalar.e(0).toString());
+        expect(dest3.accumulatedHash.toString()).to.be.equal(Scalar.e(0).toString());
+
+        // account3 to receive fees
+        expect(dest2.sign).to.be.equal(account3.sign);
+        expect(dest2.ay).to.be.equal(account3.ay);
+        expect(dest2.ethAddr).to.be.equal(account3.ethAddr);
+        expect(dest2.balance.toString()).to.be.equal(Scalar.add(feeTx1, feeTx2).toString());
+        expect(dest2.tokenID).to.be.equal(1);
+        expect(dest2.nonce).to.be.equal(0);
+        expect(dest2.exitBalance.toString()).to.be.equal(Scalar.e(0).toString());
+        expect(dest2.accumulatedHash.toString()).to.be.equal(Scalar.e(0).toString());
+
+        // check migrationIdx
+        expect(source3.sign).to.be.equal(Constants.onlyExitBjjSign);
+        expect(source3.ay).to.be.equal(Constants.onlyExitBjjAy.slice(2));
+        expect(source3.ethAddr).to.be.equal(accountDestRollup.ethAddr);
+
+        // check migration consolidate
+        expect(rollupDestDB.lastBatch).to.be.equal(oldLastBatch + 1);
+        expect(rollupDestDB.stateRoot.toString()).to.not.be.equal(oldStateRoot.toString());
+        expect(rollupDestDB.initialIdx).to.be.equal(oldInitialIdx + 1);
+    });
+
+    it("Should migrate migrationTx > Constants.minTxToMigrate in 2 batches", async () => {
+        const newMaxTx = 5 * Constants.minTxToMigrate;
+        const numTxMigrate = 2 * Constants.minTxToMigrate;
+        const newMaxMigrationTx = newMaxTx;
+
+        // RollupSourceDB
+        const db = new SMTMemDB();
+        const rollupSourceDB = await RollupDB(db);
+        const bb = await rollupSourceDB.buildBatch(newMaxTx, nLevels, maxL1Tx);
+
+        const account1 = new Account(1);
+        const accountDestRollup = new Account(3);
+
+        depositTx(bb, account1, 1, 1000);
+        depositOnlyExitTx(bb, accountDestRollup, 1, 0);
+
+        const migrationIdx = 257;
+
+        await bb.build();
+        await rollupSourceDB.consolidate(bb);
+
+        const bb2 = await rollupSourceDB.buildBatch(newMaxTx, nLevels, maxL1Tx);
+
+        let nonceTrack = 0;
+        for (let i = 0; i < numTxMigrate; i++){
+            const tx = {
+                fromIdx: 256,
+                toIdx: 257,
+                tokenID: 1,
+                amount: Scalar.e(1),
+                nonce: nonceTrack++,
+                userFee: 0,
+            };
+
+            account1.signTx(tx);
+            bb2.addTx(tx);
+        }
+
+        await bb2.build();
+        await rollupSourceDB.consolidate(bb2);
+
+        // RollupDestinyDB
+        const destDb = new SMTMemDB();
+        const rollupDestDB = await RollupDB(destDb);
+        const destBb = await rollupDestDB.buildBatch(newMaxTx, nLevels, maxL1Tx);
+
+        await rollupDestDB.setMigrationIdx(migrationIdx);
+
+        await destBb.build();
+        await rollupDestDB.consolidate(destBb);
+
+        // migration-builder
+        const initBatch = 1;
+        const finalBatch = 2;
+
+        const mb = await rollupDestDB.buildMigration(newMaxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+
+        await mb.build();
+        await rollupDestDB.consolidateMigrate(mb);
+
+        // check all migration txs has been processed
+        // first migration transaction creates a new leaf
+        // follwoing ones update that leaf
+        const dest1 = await rollupDestDB.getStateByIdx(256);
+        expect(dest1.sign).to.be.equal(account1.sign);
+        expect(dest1.ay).to.be.equal(account1.ay);
+        expect(dest1.ethAddr).to.be.equal(account1.ethAddr);
+        expect(dest1.balance.toString()).to.be.equal(Scalar.e(numTxMigrate).toString());
+        expect(dest1.tokenID).to.be.equal(1);
+        expect(dest1.nonce).to.be.equal(0);
+        expect(dest1.exitBalance.toString()).to.be.equal(Scalar.e(0).toString());
+        expect(dest1.accumulatedHash.toString()).to.be.equal(Scalar.e(0).toString());
+    });
+
+    it("Should check errors", async () => {
+        // RollupSourceDB
+        const db = new SMTMemDB();
+        const rollupSourceDB = await RollupDB(db);
+        const bb = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        const account1 = new Account(1);
+        const account2 = new Account(2);
+        const account3 = new Account(3);
+        const accountDestRollup = new Account(4);
+
+        depositTx(bb, account1, 1, 1000);
+        depositTx(bb, account2, 1, 2000);
+        depositOnlyExitTx(bb, accountDestRollup, 1, 0);
+
+        const migrationIdx = 258;
+
+        await bb.build();
+        await rollupSourceDB.consolidate(bb);
+
+        const bb2 = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+        // two sends to exit-only account
+        const tx = {
+            fromIdx: 256,
+            toIdx: 258,
+            tokenID: 1,
+            amount: Scalar.e(20),
+            nonce: 0,
+            userFee: 125,
+        };
+
+        const tx2 = {
+            fromIdx: 257,
+            toIdx: 258,
+            tokenID: 1,
+            amount: Scalar.e(100),
+            nonce: 0,
+            userFee: 127,
+        };
+
+        account1.signTx(tx);
+        account2.signTx(tx2);
+        bb2.addTx(tx);
+        bb2.addTx(tx2);
+
+        await bb2.build();
+        await rollupSourceDB.consolidate(bb2);
+
+        // RollupDestinyDB
+        const destDb = new SMTMemDB();
+        const rollupDestDB = await RollupDB(destDb);
+        const destBb = await rollupDestDB.buildBatch(maxTx, nLevels, maxL1Tx);
+
+        depositTx(destBb, account2, 1, 2000);
+        depositTx(destBb, account3, 1, 0);
+        depositTx(destBb, account3, 2, 0);
+        await rollupDestDB.setMigrationIdx(migrationIdx);
+
+        await destBb.build();
+        await rollupDestDB.consolidate(destBb);
+
+        // check error: initial batch does not exit
+        let initBatch = 3;
+        let finalBatch = 4;
+
+        const mb = await rollupDestDB.buildMigration(maxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+        try {
+            await mb.build();
+            expect(true).to.be.equal(false);
+        } catch (error){
+            expect(error.message.includes("ERROR: Initial batch to migrate does not exist")).to.be.equal(true);
+        }
+
+        // check error: final batch does not exit
+        initBatch = 1;
+        const mb2 = await rollupDestDB.buildMigration(maxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+        try {
+            await mb2.build();
+            expect(true).to.be.equal(false);
+        } catch (error){
+            expect(error.message.includes("ERROR: Final batch to migrate does not exist")).to.be.equal(true);
+        }
+
+        // check error: not enough batches or transactions
+        finalBatch = 2;
+        const mb3 = await rollupDestDB.buildMigration(maxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+        try {
+            await mb3.build();
+            expect(true).to.be.equal(false);
+        } catch (error){
+            expect(error.message.includes("ERROR: Not enough batches to migrate neither enough transactions")).to.be.equal(true);
+        }
+
+        // add empty batches to skip min batches check
+        const bbToBuild = 10;
+
+        while (rollupSourceDB.lastBatch < bbToBuild){
+            const bb = await rollupSourceDB.buildBatch(maxTx, nLevels, maxL1Tx);
+            bb.build();
+            await rollupSourceDB.consolidate(bb);
+        }
+
+        initBatch = 1;
+        finalBatch = 10;
+
+        // check error: feeIdx does not exist
+        const mb4 = await rollupDestDB.buildMigration(maxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+        mb4.setFeeIdx(260);
+        try {
+            await mb4.build();
+            expect(true).to.be.equal(false);
+        } catch (error){
+            expect(error.message.includes("ERROR: feeIdx does not exist")).to.be.equal(true);
+        }
+
+        // check error: feeIdx tokenID does not match
+        const mb5 = await rollupDestDB.buildMigration(maxMigrationTx, nLevels, rollupSourceDB, initBatch, finalBatch);
+        mb5.setFeeIdx(258);
+        try {
+            await mb5.build();
+            expect(true).to.be.equal(false);
+        } catch (error){
+            expect(error.message.includes("ERROR: feeIdx tokenID does not match with tokenID of migrationIdx")).to.be.equal(true);
+        }
+    });
+});

--- a/test/tx-utils.test.js
+++ b/test/tx-utils.test.js
@@ -7,6 +7,7 @@ const float40 = require("../index").float40;
 const Constants = require("../index").Constants;
 
 describe("Tx-utils", function () {
+
     it("tx compressed data", async () => {
         const tx = {
             chainID: 1,
@@ -66,7 +67,6 @@ describe("Tx-utils", function () {
     });
 
     it("encode decode l1-full-tx", async () => {
-
         const nLevels = 32;
         const tx = {
             toIdx: 257,
@@ -93,8 +93,8 @@ describe("Tx-utils", function () {
         const nLevels = 32;
 
         const tx = {
-            toIdx: 2**24 - 1,
-            fromIdx: 2**30,
+            toIdx: 2 ** 24 - 1,
+            fromIdx: 2 ** 30,
             amount: float40.round(Scalar.e("1982082637635472634987360")),
             userFee: 240,
         };
@@ -134,11 +134,11 @@ describe("Tx-utils", function () {
 
     it("encode decode l1-tx coordinator", async () => {
         const l1CoordinatorTx = {
-            tokenID: 2**16,
+            tokenID: 2 ** 16,
             fromBjjCompressed: "0x8efe299dccec53409219f4352d7cba8ae12b8e6d64e9352ebefec438092e8324",
             r: Scalar.shl(1, 240).toString(16),
             s: Scalar.sub(Scalar.shl(1, 256), 1).toString(16),
-            v: 2**7 - 3,
+            v: 2 ** 7 - 3,
         };
 
         const txData = `0x${txUtils.encodeL1CoordinatorTx(l1CoordinatorTx).toString(16)}`;
@@ -156,8 +156,8 @@ describe("Tx-utils", function () {
 
         const l1Tx = {
             effectiveAmount: float40.round(Scalar.e("1000000000")),
-            toIdx: 2**24 - 1,
-            fromIdx: 2**30 - 1
+            toIdx: 2 ** 24 - 1,
+            fromIdx: 2 ** 30 - 1
         };
 
         const txData = `0x${txUtils.encodeL1Tx(l1Tx, nLevels).toString(16)}`;
@@ -169,6 +169,24 @@ describe("Tx-utils", function () {
             equal(l1Tx.effectiveAmount.toString());
         expect(txDataDecoded.toIdx.toString()).to.be.equal(l1Tx.toIdx.toString());
         expect(txDataDecoded.fromIdx.toString()).to.be.equal(l1Tx.fromIdx.toString());
+    });
+
+    it("scalar to hexadecimal string L2Data", async () => {
+        const nLevels = 32;
+
+        let tx = {
+            toIdx: 2 ** 24 - 1,
+            fromIdx: 2 ** 30,
+            amount: float40.round(Scalar.e("1982082637635472634987360")),
+            userFee: 240,
+        };
+        
+        const txData = txUtils.encodeL2Tx(tx, nLevels);
+
+        const scalarTxData = Scalar.fromString(txData, 16);
+        const hexTxData = txUtils.scalarToHexL2Data(scalarTxData, nLevels);
+        
+        expect(txData).to.be.equal(hexTxData);
     });
 
     it("account creation authorization", async () => {


### PR DESCRIPTION
This pull-request implements the following:
- `migration-builder`
  - implements module to process and compute migration transactions
  - it generates all the zk-inputs for the massive-migrations circuit
- `rollupDB`
  - support building a `migration-builder` and consolidate it
  - save in DB `nLevels` and `data-availability` for each batch
  - implement `setMigrationIdx` & `getL1L2Data`
- `batch-builder`
  - adds `getL1L2TxsData` function
- `tx-utils`
  - add functionality `scalarToHexL2Data`    