### PR TITLE
Polygon Avail integration

### DIFF
--- a/src/batch-builder.js
+++ b/src/batch-builder.js
@@ -1366,6 +1366,46 @@ module.exports = class BatchBuilder {
     }
 
     /**
+     * Return nops tx data-availability
+     * fromIdx | toIdx | amountF | userFee == 0 | 0 | 0 | 0
+     * @return {String} nop tx data availability encoded as hexadecimal
+     */
+    _nopTxsData() {
+        if (!this.builded) throw new Error("Batch must first be builded");
+
+        const dataNopTx = utils.padZeros("",
+            (this.maxNTx - this.offChainTxs.length - this.onChainTxs.length) * (this.L1L2TxDataB / 4));
+        return  dataNopTx;
+    }
+
+    /**
+     * Return L1 & L2 data-availability padded with all unused L2 txs
+     * @return {String} L1 & L2 data-availability encoded as hexadecimal
+     */
+    getL1L2TxsData() {
+        if (!this.builded) throw new Error("Batch must first be builded");
+
+        const dataL1Tx = this._L1TxsData();
+        const dataL2Tx = this._L2TxsData();
+        const dataNopTx = this._nopTxsData();
+
+        return dataL1Tx.concat(dataL2Tx).concat(dataNopTx);
+    }
+
+    /**
+     * Return the L1 & L2 data-availability ready to send to the SC
+     * @return {String} L1 & L2 data encoded as hexadecimal
+     */
+    getL1L2TxsDataSM() {
+        if (!this.builded) throw new Error("Batch must first be builded");
+
+        const dataL1Tx = this._L1TxsData();
+        const dataL2Tx = this._L2TxsData();
+
+        return `0x${dataL1Tx.concat(dataL2Tx)}`;
+    }
+
+    /**
      * Return the states that have been change with the L1 transactions
      * @return {Object} Resulting temporally state
      */

--- a/test/batch-builder.test.js
+++ b/test/batch-builder.test.js
@@ -797,22 +797,6 @@ describe("Rollup Db - batchbuilder", async function(){
         "00000000" +
         "000000000000";
 
-        const resTxsData =
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000" +
-            "0000010000000101000000006400" +
-            "000001000000010100000000327e" +
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000";
-
-        const resTxsDataSM = "0x" +
-            "0000000000000000000000000000" +
-            "0000000000000000000000000000" +
-            "0000010000000101000000006400" +
-            "000001000000010100000000327e";
-
         const resFeeData = "00000104000001050000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
         + "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -820,23 +804,19 @@ describe("Rollup Db - batchbuilder", async function(){
         + "000000000000000000000000000000000000000000000000000000000";
 
         const batchL1Data = await bb.getL1TxsFullData();
-        const batchTxsData = await bb.getL1L2TxsData();
-        const batchTxsDataSM = await bb.getL1L2TxsDataSM();
         const batchFeeData = await bb.getFeeTxsData();
 
         expect(resL1Data).to.be.equal(batchL1Data.toString());
-        expect(resTxsData).to.be.equal(batchTxsData.toString());
-        expect(resTxsDataSM).to.be.equal(batchTxsDataSM.toString());
         expect(resFeeData).to.be.equal(batchFeeData.toString());
 
         // input hash
-        const resInputHash = "12514623173775018362376319619542083816299433114758195525580469850532085559598";
+        const resInputHash = "3458885215479968911184210621510827723849325542189853870937075805424197015753";
 
         const batchInputHash = await bb.getHashInputs();
         expect(resInputHash).to.be.equal(batchInputHash.toString());
     });
 
-    it("Should check empty L1, L2, Fee data", async () => {
+    it("Should check empty L1, Fee data", async () => {
         // Start a new state
         const db = new SMTMemDB();
         const rollupDB = await RollupDB(db);
@@ -845,21 +825,18 @@ describe("Rollup Db - batchbuilder", async function(){
         await bb.build();
         await rollupDB.consolidate(bb);
 
-        // Check L1, L2, Fee data
+        // Check L1, Fee data
         const resL1Data = "0".repeat(864+6*6*2);
-        const resL2Data = "0".repeat(176+8*3*2);
         const resFeeData = "0".repeat(512);
 
         const batchL1Data = await bb.getL1TxsFullData();
-        const batchL2Data = await bb.getL1L2TxsData();
         const batchFeeData = await bb.getFeeTxsData();
 
         expect(batchL1Data.toString()).to.be.equal(resL1Data);
-        expect(batchL2Data.toString()).to.be.equal(resL2Data);
         expect(batchFeeData.toString()).to.be.equal(resFeeData);
 
         // input hash
-        const resInputHash = "9089028054588104462886776521837774802942784059202308502651705027859889271172";
+        const resInputHash = "19180511163151641727886597577570644697313744806197186474407541518839573172442";
 
         const batchInputHash = await bb.getHashInputs();
         expect(resInputHash).to.be.equal(batchInputHash.toString());


### PR DESCRIPTION
This PR is the beginning of the integration with Polygon Avail. We should remove data availability L1L2txData from the batch builder so this data will be available in Polygon Avail instead of the tx calldata.
- Remove L1L2txData from `batch-builder.js`.
- Update test `batch-builder.test.js`.

